### PR TITLE
removed redirects to undefined

### DIFF
--- a/files/pt-pt/_redirects.txt
+++ b/files/pt-pt/_redirects.txt
@@ -622,7 +622,6 @@
 /pt-PT/docs/XForms:Controles_Customizados	/pt-PT/docs/XForms/Controles_Customizados
 /pt-PT/docs/XML:Comunidade	/pt-PT/docs/XML/Comunidade
 /pt-PT/docs/XML:Outros_Recursos	/pt-PT/docs/XML/Outros_Recursos
-/pt-PT/docs/XPInstall	undefined
 /pt-PT/docs/XPath	/pt-PT/docs/Web/XPath
 /pt-PT/docs/XPath:Eixos	/pt-PT/docs/XPath/Eixos
 /pt-PT/docs/XPath:Fun%C3%A7%C3%B5es	/pt-PT/docs/XPath/Fun%C3%A7%C3%B5es

--- a/files/zh-cn/_redirects.txt
+++ b/files/zh-cn/_redirects.txt
@@ -59,8 +59,6 @@
 /zh-CN/docs/%E8%BF%99%E6%98%AF%E4%B8%80%E4%B8%AA%E4%BE%8B%E5%AD%90	/zh-CN/docs/junks/%E8%BF%99%E6%98%AF%E4%B8%80%E4%B8%AA%E4%BE%8B%E5%AD%90
 /zh-CN/docs/%E9%80%9A%E8%BF%87CVS%E8%8E%B7%E5%8F%96%E6%BA%90%E7%A0%81	/zh-CN/docs/Mozilla/Developer_guide/Source_Code/CVS
 /zh-CN/docs/%E9%80%9A%E8%BF%87Mercurial%E8%8E%B7%E5%8F%96%E6%BA%90%E7%A0%81	/zh-CN/docs/temppath
-/zh-CN/docs/%E9%99%84%E5%8A%A0%E7%BB%84%E4%BB%B6	undefined
-/zh-CN/docs/%E9%9D%A2%E5%90%91%E5%AF%B9%E8%B1%A1JavaScript%E5%85%A5%E9%97%A8	undefined
 /zh-CN/docs/%E9%A1%B9%E7%9B%AE%E8%AF%B4%E6%98%8E	/zh-CN/docs/junks/%E9%A1%B9%E7%9B%AE%E8%AF%B4%E6%98%8E
 /zh-CN/docs/%E9%A1%B9%E7%9B%AE%E8%AF%B4%E6%98%8E/Page_Title	/zh-CN/docs/junks/Page_Title
 /zh-CN/docs/%E9%A1%B9%E7%9B%AE:%E6%9C%AC%E5%9C%B0%E5%8C%96%E9%A1%B9%E7%9B%AE	/zh-CN/docs/Project:Localization_Projects
@@ -606,7 +604,6 @@
 /zh-CN/docs/DOM/event.button	/zh-CN/docs/Web/API/event.button
 /zh-CN/docs/DOM/event.cancelBubble	/zh-CN/docs/Web/API/UIEvent/cancelBubble
 /zh-CN/docs/DOM/event.cancelable	/zh-CN/docs/Web/API/Event/cancelable
-/zh-CN/docs/DOM/event.charCode	undefined
 /zh-CN/docs/DOM/event.currentTarget	/zh-CN/docs/Web/API/Event/currentTarget
 /zh-CN/docs/DOM/event.defaultPrevented	/zh-CN/docs/Web/API/Event/defaultPrevented
 /zh-CN/docs/DOM/event.isChar	/zh-CN/docs/Web/API/UIEvent/isChar
@@ -1435,7 +1432,6 @@
 /zh-CN/docs/QA	/zh-CN/docs/%E8%B4%A8%E9%87%8F%E4%BF%9D%E8%AF%81
 /zh-CN/docs/RDF	/zh-CN/docs/Web/RDF
 /zh-CN/docs/RDF_%E7%AE%80%E4%BB%8B	/zh-CN/docs/junks/RDF_%E7%AE%80%E4%BB%8B
-/zh-CN/docs/Rhino_documentation	undefined
 /zh-CN/docs/Rich-Text_Editing_in_Mozilla	/zh-CN/docs/Web/Guide/HTML/Content_Editable/Rich-Text_Editing_in_Mozilla
 /zh-CN/docs/Roll_your_own_browser_-_An_embedding_HowTo_(external)	/zh-CN/docs/junks/Gecko/Embedding_Mozilla/Roll_your_own_browser_-_An_embedding_HowTo_(external)
 /zh-CN/docs/SVG	/zh-CN/docs/Web/SVG
@@ -1465,7 +1461,6 @@
 /zh-CN/docs/The_Mozilla_platform_Mozilla%E5%B9%B3%E5%8F%B0	/zh-CN/docs/junks/Mozilla%E5%B9%B3%E5%8F%B0
 /zh-CN/docs/Themes	/zh-CN/docs/junks/Themes
 /zh-CN/docs/Tips_for_Authoring_Fast-loading_HTML_Pages	/zh-CN/docs/Web/Guide/HTML/Tips_for_authoring_fast-loading_HTML_pages
-/zh-CN/docs/Toolkit_API/Official_References	undefined
 /zh-CN/docs/Toolkit_API:Official_References	/zh-CN/docs/Toolkit_API/Official_References
 /zh-CN/docs/Tools-840092-dup/Remote_Debugging	/zh-CN/docs/Tools/Remote_Debugging
 /zh-CN/docs/Tools-840092-dup/Tools_Toolbox	/zh-CN/docs/Tools/Tools_Toolbox

--- a/files/zh-tw/_redirects.txt
+++ b/files/zh-tw/_redirects.txt
@@ -681,7 +681,6 @@
 /zh-TW/docs/Web/JavaScript/JavaScript_typed_arrays/ArrayBuffer/prototype	/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/prototype
 /zh-TW/docs/Web/JavaScript/New_in_JavaScript/JavaScript_1.6_%E6%96%B0%E9%AE%AE%E4%BA%8B	/zh-TW/docs/Web/JavaScript/New_in_JavaScript/1.6
 /zh-TW/docs/Web/JavaScript/New_in_JavaScript/JavaScript_1.7_%E6%96%B0%E9%AE%AE%E4%BA%8B	/zh-TW/docs/Web/JavaScript/New_in_JavaScript/1.7
-/zh-TW/docs/Web/JavaScript/Obsolete_Pages	undefined
 /zh-TW/docs/Web/JavaScript/Obsolete_Pages/Control_flow_and_error_handling	/zh-TW/docs/Web/JavaScript/Guide/Control_flow_and_error_handling
 /zh-TW/docs/Web/JavaScript/Obsolete_Pages/Expressions_and_Operators	/zh-TW/docs/Web/JavaScript/Guide/Expressions_and_Operators
 /zh-TW/docs/Web/JavaScript/Obsolete_Pages/Keyed_collections	/zh-TW/docs/Web/JavaScript/Guide/Keyed_collections


### PR DESCRIPTION
There were 7 of these strange nonsense redirects, that either redirect to themselves or to a non-existent document.

Here's what they were in the production DB:
- /pt-PT/docs/XPInstall: `<p>REDIRECT <a href="/pt-PT/docs/XPInstall" class="redirect">XPInstall</a></p>`
- /zh-CN/docs/%E9%99%84%E5%8A%A0%E7%BB%84%E4%BB%B6: `REDIRECT <a class="redirect" href="/docs/zh-cn/%E9%99%84%E5%8A%A0%E7%BB%84%E4%BB%B6">zh-cn/附加组件</a>`
- /zh-CN/docs/%E9%9D%A2%E5%90%91%E5%AF%B9%E8%B1%A1JavaScript%E5%85%A5%E9%97%A8 : `REDIRECT <a class="redirect" href="/docs/zh-cn/%E9%9D%A2%E5%90%91%E5%AF%B9%E8%B1%A1JavaScript%E5%85%A5%E9%97%A8">zh-cn/面向对象JavaScript入门</a>`
- /zh-CN/docs/DOM/event.charCode : `REDIRECT <a class="redirect" href="/docs/zh-cn/DOM/event.charCode">zh-cn/DOM/event.charCode</a>`
- /zh-CN/docs/Rhino_documentation: `REDIRECT <a class="redirect" href="/docs/zh-cn/Rhino_documentation">zh-cn/Rhino_documentation</a>`
- /zh-CN/docs/Toolkit_API/Official_References : `REDIRECT <a class="redirect" href="/docs/zh-cn/Toolkit_API/Official_References">zh-cn/Toolkit_API/Official_References</a>`
- /zh-TW/docs/Web/JavaScript/Obsolete_Pages : `<p>REDIRECT <a class="redirect" href="/zh-TW/docs/Web/JavaScript/Obsolete_Pages">JavaScript 指南</a></p>`