### PR TITLE
Rectified wrong alignment of examples in "Element.classList"

### DIFF
--- a/files/ru/web/api/element/classlist/index.html
+++ b/files/ru/web/api/element/classlist/index.html
@@ -54,10 +54,10 @@ translation_of: Web/API/Element/classList
 
 <h2 id="Примеры">Примеры</h2>
 
-<pre class="brush: js" dir="rtl">&lt;div id=&quot;clock&quot; class=&quot;example for you&quot;&gt; &lt;/div&gt;
+<pre class="brush: js" dir="tlr">&lt;div id=&quot;clock&quot; class=&quot;example for you&quot;&gt; &lt;/div&gt;
 </pre>
 
-<pre class="brush: js" dir="rtl">var elem = document.querySelector(&quot;#clock&quot;)
+<pre class="brush: js" dir="tlr">var elem = document.querySelector(&quot;#clock&quot;)
 
 //Выведем классы
 console.log(elem.classList); //DOMTokenList [&quot;example&quot;, &quot;for&quot;, &quot;you&quot;]


### PR DESCRIPTION
This fixes https://github.com/mdn/content/issues/2227
